### PR TITLE
Set up environment variables using dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,14 @@
 # Node
 node_modules/
-.env
 dist/
 build/
 dist-ssr
 *.local
+
+# Environment variables
+.env
+.env.test
+.env.production
 
 # Logs
 logs

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,8 @@
+# Port the Express server runs on
 PORT=3000
-DATABASE_URL=postgres://user:password@localhost:5432/pet_db
-JWT_SECRET=your_jwt_secret
+
+# MongoDB or PostgreSQL database connection URL
+DATABASE_URL=https://example.com/your-database
+
+# Application environment
+NODE_ENV=development  # development | production | test

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^5.1.0"
+        "dotenv": "^17.2.0",
+        "express": "^5.1.0",
+        "zod": "^4.0.5"
       },
       "devDependencies": {
         "@types/express": "^5.0.3",
@@ -23,6 +25,7 @@
         "nodemon": "^3.1.10",
         "prettier": "^3.6.2",
         "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "^5.8.3",
         "vitest": "^3.2.4"
       }
@@ -2267,6 +2270,18 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3369,6 +3384,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3564,6 +3592,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -4517,6 +4555,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4763,6 +4811,21 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/type-check": {
@@ -5232,6 +5295,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
+      "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,8 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "express": "^5.1.0"
+    "dotenv": "^17.2.0",
+    "express": "^5.1.0",
+    "zod": "^4.0.5"
   }
 }

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,39 @@
+import dotenv from 'dotenv';
+import path from 'path';
+import fs from 'fs';
+import { z } from 'zod';
+
+const nodeEnv = process.env.NODE_ENV || 'development';
+
+const envFileMap: Record<string, string> = {
+  development: '.env',
+  test: '.env.test',
+  production: '.env.production',
+};
+
+const envFile = envFileMap[nodeEnv] ?? '.env';
+const envPath = path.resolve(process.cwd(), envFile);
+
+if (!fs.existsSync(envPath)) {
+  console.error(`❌ Required environment file "${envFile}" not found`);
+  process.exit(1);
+}
+
+dotenv.config({ path: envPath, override: true });
+console.log(`✅ Loaded environment variables from ${envFile}`);
+
+// Validate environmanr variables
+const envSchema = z.object({
+  PORT: z.coerce.number().optional().default(3000),
+  DATABASE_URL: z.string().url(),
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+});
+
+const parsed = envSchema.safeParse(process.env);
+
+if (!parsed.success) {
+  console.error('❌ Invalid environment variables:\n', parsed.error.format());
+  process.exit(1);
+}
+
+export const env = parsed.data;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,12 +1,13 @@
+import 'dotenv/config';
 import express from 'express';
+import { env } from './config/env.js';
 
 const app = express();
-const port = process.env.PORT || 3000;
 
 app.get('/', (_req, res) => {
   res.send('Hello, TypeScript and Express!');
 });
 
-app.listen(port, () => {
-  console.log(`Server is running at http://localhost:${port}`);
+app.listen(env.PORT, () => {
+  console.log(`Server is running on port ${env.PORT}`);
 });


### PR DESCRIPTION
### Usage

This project uses `dotenv` for environment variable management and `Zod` for type-safe validation of these variables.

Use sample `.env.example` for adding environment variables.

```
# Port the Express server runs on
PORT=3000

# PostgreSQL database connection string
DATABASE_URL=postgres://user:pass@localhost:5432/your-db

# Environment: development | production | test
NODE_ENV=development
```

Copy `.env.example` and rename it to `.env`, `.env.test`, or `.env.production` depending on your usage: `cp .env.example .env`

### Supported Environments

File | Purpose
-- | --
`.env` | Default local environment
`.env.test` | Used during testing
`.env.production` | For production deployment

The correct file is loaded based on the value of `NODE_ENV`.

```
# Development
npm run dev
NODE_ENV=development npm run dev

# Test
NODE_ENV=test npm run dev

# Production
NODE_ENV=production npm run dev
```
